### PR TITLE
AISDK-102: Remove silent retry on connection errors

### DIFF
--- a/src/main/java/revai/ApiClient.java
+++ b/src/main/java/revai/ApiClient.java
@@ -42,6 +42,7 @@ public class ApiClient {
         new OkHttpClient.Builder()
             .addNetworkInterceptor(new ApiInterceptor(accessToken, SDKHelper.getSdkVersion()))
             .addNetworkInterceptor(new ErrorInterceptor())
+            .retryOnConnectionFailure(false)
             .build();
     this.retrofit =
         new Retrofit.Builder()


### PR DESCRIPTION
OkHttp has a built-in silent retry feature. When the client receives error responses or IO exceptions during a request it will silently retry the request for an indefinite number of times. This was causing the client to become stuck in an infinite loop and also prevented the rev ai exceptions from propagating up. 