### PR TITLE
AISDK-182: Add broken link checker to github actions

### DIFF
--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@e1ef974431881438bf594f458e332b099fd33bb5 #v1.4.1 https://github.com/lycheeverse/lychee-action#security-tip
         with:
+          args: --verbose --no-progress './**/*.md' './**/*.html' './**/*.java'
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -1,0 +1,18 @@
+name: Links (Fail Fast)
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@e1ef974431881438bf594f458e332b099fd33bb5 #v1.4.1 https://github.com/lycheeverse/lychee-action#security-tip
+        with:
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -1,4 +1,4 @@
-name: Links (Fail Fast)
+name: Broken Link Checker
 
 on:
   push:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+api.rev.ai

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,5 @@
+# API Domain stubs used as url partials in the api clients
 api.rev.ai
+
+# example domains used in unit tests
+www.example.com

--- a/src/test/java/ai/rev/speechtotext/unit/RevAiCustomVocabularyTest.java
+++ b/src/test/java/ai/rev/speechtotext/unit/RevAiCustomVocabularyTest.java
@@ -35,7 +35,7 @@ public class RevAiCustomVocabularyTest {
 
   private final MediaType MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
   private final String VOCABULARY_URL = "https://api.rev.ai/revspeech/v1/vocabularies";
-  private final String CALLBACK_URL = "https://test.callback.url";
+  private final String CALLBACK_URL = "https://callback.example.com";
   private final String DATE = new Date().toString();
   private final String ID = "TEST";
   private Gson gson;

--- a/src/test/java/ai/rev/speechtotext/unit/RevAiCustomVocabularyTest.java
+++ b/src/test/java/ai/rev/speechtotext/unit/RevAiCustomVocabularyTest.java
@@ -35,7 +35,7 @@ public class RevAiCustomVocabularyTest {
 
   private final MediaType MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
   private final String VOCABULARY_URL = "https://api.rev.ai/revspeech/v1/vocabularies";
-  private final String CALLBACK_URL = "https://callback.example.com";
+  private final String CALLBACK_URL = "https://www.example.com";
   private final String DATE = new Date().toString();
   private final String ID = "TEST";
   private Gson gson;


### PR DESCRIPTION
After implementing the previous ticket AISDK-179 (#36), I decided to explore link checking options to reduce verification time and prevent broken links from occurring in future deploys. You can review the Github Actions runs for this new action here: https://github.com/revdotcom/revai-java-sdk/actions/workflows/links-fail-fast.yml.

If we like this approach then we can implement it for our other repositories as well.