### PR TITLE
remove okhttp3 internal Util usage

### DIFF
--- a/src/main/java/ai/rev/speechtotext/FileStreamRequestBody.java
+++ b/src/main/java/ai/rev/speechtotext/FileStreamRequestBody.java
@@ -2,7 +2,6 @@ package ai.rev.speechtotext;
 
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
-import okhttp3.internal.Util;
 import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
@@ -27,7 +26,18 @@ public class FileStreamRequestBody {
           source = Okio.source(inputStream);
           sink.writeAll(source);
         } finally {
-          Util.closeQuietly(source);
+          try {
+            source.close();
+          } catch (AssertionError ae) {
+            throw ae;
+          } catch (RuntimeException re) {
+            if ("bio == null".equals(re.getMessage())) {
+              // Conscrypt in Android 10 and 11 may throw closing an SSLSocket. This is safe to ignore.
+              // https://issuetracker.google.com/issues/177450597
+              return;
+            }
+            throw re;
+          } catch (Exception ignore) {}
         }
       }
     };


### PR DESCRIPTION
FileStreamRequestBody was calling the method closeQuietly() from okhttp3.internal.Util, which was removed in okhttp3 release 5, and anyhow shouldn't be used since it's 'internal' and therefore not intended for shared use. I reproduced the effect of closeQuitely() directly in the finally{} block instead.